### PR TITLE
Update docker documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,9 @@ Given a honeypot network in your organization, it should be easy to use AIP to g
 
 ![Description of the AIP pipeline](images/AIP_Diagram.png "AIP Tool pipeline")
 
+## Docker
 
+Check the instructions on how to run the AIP using [Docker](etc/docker/README.md).
+
+# About
+This tool was developed at the Stratosphere Laboratory at the Czech Technical University in Prague.

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -1,21 +1,45 @@
 # Docker image for AIP
+
 AIP docker aims to help in development and deployment of AIP algorithms to newcommers. The code of the repository is mounted and available from inside the docker image. The source of the data and the output folder of AIP is also mounted as a data volume inside the data/ folder to decouple from where this data really is in the host machine, easying the AIP deployment.
 
-### Build the image
+## Build the image
+
 To build the image, you can run the following command.
-```
-docker build --file etc/docker/Dockerfile --tag aip:aip .
+
+```bash
+:~$ git clone https://github.com/stratosphereips/AIP.git
+:~$ cd AIP/
+:~/AIP$ docker build --build-arg uid=1000 --file etc/docker/Dockerfile --tag aip:latest .
 ```
 
-### Run the container
-To run the container of that image you can run the following command. This will mount the root folder of the project in $HOME/AIP inside the docker container.
-```
-docker run --rm -v $(pwd):/home/aip/AIP/:rw -it aip:aip bash
+## Prepare the data
+
+AIP needs raw network flow data to run. In this case, we assume you have Zeek logs in `/opt/zeek/logs`. 
+
+Additionally, the following two files need to be edited and populated:
+- `data/external/do_not_block_these_ips_example.csv`: you want to add here IPs that should not appear on the AIP blocklists
+- `data/external/honeypots_public_ips_example.csv`: you want to add here the public IP of the honeypot or machine running Zeek
+
+First copy the files and then edit them:
+```bash
+:~/AIP$ cp data/external/do_not_block_these_ips_example.csv data/external/do_not_block_these_ips.csv
+:~/AIP$ cp data/external/honeypots_public_ips_example.csv data/external/honeypots_public_ips.csv
 ```
 
-### Run the tests
-Once inside the container you need to activate the conda aip environment in order to be able to run the tests.
-```
-(aip) aip@a2aa875c07cf:~/AIP$ pytest tests/
+## Run the container
+
+To run the container of that image you can run the following command:
+
+```bash
+:~/AIP$ docker run --rm -v /opt/zeek/logs/:/home/aip/AIP/data/raw:ro -v ${PWD}/data/:/home/aip/AIP/data/:rw --name aip aip:latest bin/aip
 ```
 
+An example output is shown below:
+```
+2024-10-23 13:02:36,513 - aip.data.access - DEBUG - Creating attacks for dates ['2024-10-22']
+2024-10-23 13:02:36,513 - aip.data.access - DEBUG - Making  dataset from raw data for dates ['2024-10-22']
+2024-10-23 13:02:37,197 - aip.data.access - DEBUG - Writting file: /home/aip/AIP/data/interim/daily.conn.2024-10-22.csv.gz
+2024-10-23 13:02:37,539 - aip.data.access - DEBUG - Writting file: /home/aip/AIP/data/processed/attacks.2024-10-22.csv.gz
+2024-10-23 13:02:37,648 - aip.data.access - DEBUG - Creating attacks for dates ['2024-10-20', '2024-10-21']
+...
+```


### PR DESCRIPTION
# Description

This PR includes two changes:
- Update the docker README with fresh instructions (`etc/docker/README.md`)
- Update the repository REAMDE to point users to the docker instructions (`README.md`)

The instructions on how to run the AIP tests that was included in the `etc/docker/README.md` were removed given that none of the current branches (`main` or `development`) has any test files on them.