### PR TITLE
Bring back tests to AIP

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,3 +31,4 @@ Dockerfile_MacM1
 images/
 .github
 data/
+tests/

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 .idea/
 .env
-*__pycache__*
-src/data/__pycache__/
+__pycache__/
 *-run.sh
 venv/
 *.venv/
 *.swp
+

--- a/tests/test_lib_aip_utils_date_utils.py
+++ b/tests/test_lib_aip_utils_date_utils.py
@@ -1,0 +1,52 @@
+import unittest
+import logging
+from datetime import date
+from lib.aip.utils.date_utils import validate_and_convert_date
+
+
+# Suppress logging messages below CRITICAL level
+# to just get the result of the tests.
+logging.disable(logging.CRITICAL)
+
+class TestValidateAndConvertDate(unittest.TestCase):
+
+    def test_valid_date(self):
+        # Test with a valid date
+        self.assertEqual(validate_and_convert_date("2024-10-27"), date(2024, 10, 27))
+
+    def test_empty_string(self):
+        # Test with an empty string
+        with self.assertRaises(ValueError):
+            validate_and_convert_date("")
+
+    def test_invalid_format(self):
+        # Test with various invalid formats
+        with self.assertRaises(ValueError):
+            validate_and_convert_date("2024/10/27")
+
+        with self.assertRaises(ValueError):
+            validate_and_convert_date("27-10-2024")
+
+        with self.assertRaises(ValueError):
+            validate_and_convert_date("October 27, 2024")
+
+    def test_nonexistent_date(self):
+        # Test not existing date Feb 30th
+        with self.assertRaises(ValueError):
+            validate_and_convert_date("2024-02-30")
+
+        # Test not existing month 13
+        with self.assertRaises(ValueError):
+            validate_and_convert_date("2024-13-01")
+
+    def test_none_value(self):
+        # Test with None as input
+        with self.assertRaises(TypeError):
+            validate_and_convert_date(None)
+
+    def test_edge_case(self):
+        # Test leap years
+        self.assertEqual(validate_and_convert_date("2024-02-29"), date(2024, 2, 29))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR is bring back an initial set of tests for AIP, specifically now for the `lib/aip/utils/date_utils.py` functionality.

The test folder is ignored in the .dockerignore for now. 